### PR TITLE
Feat : 웹소켓 초기설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+
+    // 웹소켓 관련 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/plink/backend/config/WebSocketConfig.java
+++ b/src/main/java/com/plink/backend/config/WebSocketConfig.java
@@ -1,0 +1,34 @@
+package com.plink.backend.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*") // 추후 보안면에서 수정 (프론트 도메인만 허용하도록)
+                .withSockJS();
+        // 순수 WS만 쓰려면 .withSockJS() 제거
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 서버 -> 클라이언트
+        registry.enableSimpleBroker("/topic", "/queue");
+
+        // 클라이언트 -> 서버
+        registry.setApplicationDestinationPrefixes("/send");
+
+        // 1:1 전송
+        registry.setUserDestinationPrefix("/user");
+    }
+}


### PR DESCRIPTION
## 📌 이슈번호 및 PR 유형
<!-- closed #이슈번호 -->
closed #2 
---

## PR 유형 
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링(동작 변경 없음)
- [ ] Test: 테스트 코드 추가/수정
- [ ] Chore: 빌드/배포/환경설정 등 잡무

---

## 📝 개요
<!-- 이번 PR에서 어떤 작업을 했는지 간단히 설명 -->
- 서버-클라이언트 간의 실시간 통신을 위한 웹소켓 초기 설정 
---

## 🔍 변경 사항
<!-- 주요 변경 내용 리스트 -->
ex) - `UserController`에 로그인 POST 메서드 추가
- config 폴더 생성
- config/WebSocketConfig.java 생성

---
## Review Notes 


##  WebSocket 기능 추가 개요

이번 PR에서는 **WebSocket(STOMP)** 기반 실시간 통신 기능의 기본 세팅을 추가했습니다.  
WebSocket은 기존의 HTTP 요청/응답 방식과 달리,  
**한 번 연결되면 서버와 클라이언트가 지속적으로 세션을 유지하며 양방향으로 메시지를 주고받을 수 있는 통신 방식**입니다.  
(예: 채팅, 실시간 알림, 피드 실시간 갱신 등에서 사용)


## 적용 구조 요약

- **기존 REST API**
  - 데이터 생성·수정·삭제 등 CRUD 처리 (DB 반영 및 검증 담당)
- **WebSocket**
  - REST 요청이 성공하면 서버에서 실시간으로 다른 클라이언트에게 변경사항을 **방송(Broadcast)**
  - 클라이언트는 새로고침 없이 실시간으로 화면이 업데이트됨

> 💬 예시  
> 사용자가 `POST /api/posts` 로 새 글을 작성하면,  
> 서버는 DB에 저장 후 `/topic/post` 로 WebSocket 메시지를 전송 →  
> 피드 화면을 보고 있는 모든 사용자가 실시간으로 새 글을 확인 가능

-> 예시에서와 같이 REST API의 요청이 성공하고 나면 WebSocket 메세지가 전송됩니다. 웹소켓이 사용될 때도 프론트와의 연결이 필요하기 때문에 API 명세서페이지에 새롭게 표 만들어서 이 내용도 추가해뒀습니다! 작업하시면서 더 추가해주시면 좋을 것 같습니다
<img width="1352" height="392" alt="image" src="https://github.com/user-attachments/assets/6b446b41-8f49-4db5-96a2-fef44bab4125" />

## 기본 설정 (WebSocketConfig)

### 라우팅 규칙

| 방향 | Prefix | 설명 |
|------|---------|------|
| **클라이언트 → 서버** | (일반 요청은 REST API로 처리) | 게시글 작성, 수정, 삭제 등은 기존 REST API 사용 |
| **서버 → 클라이언트 (전체 방송)** | `/topic/**` | 모든 사용자가 구독 중인 채널로 실시간 방송 |
| **서버 → 클라이언트 (개인 전송)** | `/user/**` | 특정 사용자에게만 전송되는 개인 메시지 (알림 등) |

**예시**
- 서버가 전체 유저에게 새 글 방송 → `/topic/post`  
- 서버가 특정 유저에게 알림 전송 → `/user/queue/notify`

---

### 메시지 타입 (Message Type)

서버 → 클라이언트로 전송되는 메시지에는 **`type` 필드를 포함하여 이벤트 종류를 구분**할 수 있습니다.  
프론트에서는 이 `type` 값으로 분기 처리합니다.

<img width="693" height="382" alt="image" src="https://github.com/user-attachments/assets/16170fc9-58e3-4cae-8edd-0683f68e7816" />

- 메세지 타입은 기능에 맞게 설정해서 사용하시면 될 것 같습니다!
- 사진은 피드관련 메세지 타입의 예시입니다.

**예시 JSON**
```json
{
  "type": "POST_CREATED",
  "postId": 1,
  "author": "seoah",
  "content": "첫 글이에요!"
}






