### PR TITLE
Feat: 프로필 이미지 S3로 반환

### DIFF
--- a/src/main/java/com/plink/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/plink/backend/auth/controller/AuthController.java
@@ -26,12 +26,9 @@ public class AuthController {
     // 회원가입
     @PostMapping(value = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UserResponse> signUp(
-            @RequestPart("email") String email,
-            @RequestPart("nickname") String nickname,
-            @RequestPart("password") String password,
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+            @ModelAttribute SignUpRequest request
     ) throws IOException {
-        UserResponse response = authService.signUp(email, nickname, password, profileImage);
+        UserResponse response = authService.signUp(request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/plink/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/plink/backend/auth/controller/AuthController.java
@@ -7,8 +7,12 @@ import com.plink.backend.auth.dto.UserResponse;
 import com.plink.backend.auth.service.AuthService;
 import com.plink.backend.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/auth")
@@ -20,11 +24,17 @@ public class AuthController {
     }
 
     // 회원가입
-    @PostMapping("/signup")
-    public ResponseEntity<UserResponse> signUp(@RequestBody SignUpRequest request) {
-        UserResponse userResponse = authService.signUp(request);
-        return ResponseEntity.ok(userResponse);
+    @PostMapping(value = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<UserResponse> signUp(
+            @RequestPart("email") String email,
+            @RequestPart("nickname") String nickname,
+            @RequestPart("password") String password,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+    ) throws IOException {
+        UserResponse response = authService.signUp(email, nickname, password, profileImage);
+        return ResponseEntity.ok(response);
     }
+
 
     // 회원 로그인
     @PostMapping("/login")

--- a/src/main/java/com/plink/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/plink/backend/auth/controller/AuthController.java
@@ -49,8 +49,13 @@ public class AuthController {
     }
 
     // 게스트 세션 생성
-    @PostMapping("/guest")
-    public UserResponse guest(@RequestBody GuestRequest guestRequest) {
-        return authService.createGuest(guestRequest);
+    @PostMapping(value = "/guest", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<UserResponse> guestLogin(
+            @RequestPart("nickname") String nickname,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+    ) throws IOException {
+        UserResponse guest = authService.createGuest(nickname, profileImage);
+        return ResponseEntity.ok(guest);
     }
+
 }

--- a/src/main/java/com/plink/backend/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/plink/backend/auth/dto/SignUpRequest.java
@@ -2,11 +2,12 @@ package com.plink.backend.auth.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter @Setter
 public class SignUpRequest {
     private String email;
     private String nickname;
     private String password;
-    private String profileImageUrl;
+    private MultipartFile profileImage;
 }


### PR DESCRIPTION
## 📌 이슈번호 및 PR 유형
closed #11 

---

## PR 유형 
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [x] Refactor: 리팩토링(동작 변경 없음)
- [ ] Test: 테스트 코드 추가/수정
- [ ] Chore: 빌드/배포/환경설정 등 잡무

---

## 📝 개요
<!-- 이번 PR에서 어떤 작업을 했는지 간단히 설명 -->
**- 회원가입, 게스트 로그인 시 프로필에 사진 파일을 받아서 사진 url을 반환하도록 S3와 연동**

---

## 🔍 변경 사항
<!-- 주요 변경 내용 리스트 -->
- @Transactional 어노테이션은 조회용 엔드포인트만 (readOnly = true) 속성 부여. 나머지는 이 부분 해제하여 DB에 INSERT, DELETE 가능하도록 함 
- 회원가입 로직에서 
    - 회원 생성 시, 이메일과 닉네임 우선적으로 중복 불가능하도록 설정
    - S3 업로드 실패 관련 예외 로직 설정
    - 비밀번호 암호화 설정. 
- S3 연동 위한 액세스 키 및 비밀 액세스 키 발급, 인텔리제이 환경변수 설정 

---

## 📷 스크린샷(선택)
<!-- API 응답 포스트맨 예시 등 -->
- 일반 회원가입
<img width="1750" height="1147" alt="image" src="https://github.com/user-attachments/assets/78d9d9ff-c565-499b-8736-b6925ccb4587" />

- 게스트 로그인
<img width="1739" height="1037" alt="image" src="https://github.com/user-attachments/assets/0c1d6af1-2a28-423f-8baa-ff30a1d27522" />

- 회원가입한 사용자가 로그인 되는 것 확인
<img width="1739" height="1068" alt="image" src="https://github.com/user-attachments/assets/08df0560-834b-4eb0-bb5f-2125f74d14af" />


---

## Review Notes 
리뷰어에게 공유할 중요 사항이 있다면 알려주세요~!

추후 닉네임 중복불가를 USER, GUEST 사이에서 통합하는 작업이랑, 예외처리 로직 세분화하는 작업 진행될 것 같습니다!

---

## ✅ PR 전 체크리스트
작성하신 코드가 다음의 요구사항을 만족하는지 확인해주세요. 

- [X] 변경 사항에 대한 테스트 여부
- [X] 불필요한 콘솔 로그 제거
