### PR TITLE
Feat: 닉네임 중복정책 수정

### DIFF
--- a/src/main/java/com/plink/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/plink/backend/auth/controller/AuthController.java
@@ -25,13 +25,10 @@ public class AuthController {
 
     // 회원가입
     @PostMapping(value = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<UserResponse> signUp(
-            @ModelAttribute SignUpRequest request
-    ) throws IOException {
+    public ResponseEntity<UserResponse> signUp(@ModelAttribute SignUpRequest request) throws IOException {
         UserResponse response = authService.signUp(request);
         return ResponseEntity.ok(response);
     }
-
 
     // 회원 로그인
     @PostMapping("/login")
@@ -48,10 +45,11 @@ public class AuthController {
     // 게스트 세션 생성
     @PostMapping(value = "/guest", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UserResponse> guestLogin(
+            @RequestPart("slug") String slug,
             @RequestPart("nickname") String nickname,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) throws IOException {
-        UserResponse guest = authService.createGuest(nickname, profileImage);
+        UserResponse guest = authService.createGuest(slug, nickname, profileImage);
         return ResponseEntity.ok(guest);
     }
 

--- a/src/main/java/com/plink/backend/auth/dto/GuestRequest.java
+++ b/src/main/java/com/plink/backend/auth/dto/GuestRequest.java
@@ -8,5 +8,6 @@ import lombok.Setter;
 public class GuestRequest {
     private String nickname;
     private String profileImageUrl;
+    private String slug; // 행사 식별자
 }
 

--- a/src/main/java/com/plink/backend/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/plink/backend/auth/dto/SignUpRequest.java
@@ -10,4 +10,5 @@ public class SignUpRequest {
     private String nickname;
     private String password;
     private MultipartFile profileImage;
+    private String slug; // 행사 식별자
 }

--- a/src/main/java/com/plink/backend/auth/dto/UserResponse.java
+++ b/src/main/java/com/plink/backend/auth/dto/UserResponse.java
@@ -1,6 +1,7 @@
 package com.plink.backend.auth.dto;
 
 import com.plink.backend.user.entity.User;
+import com.plink.backend.user.entity.UserFestival;
 import lombok.Getter;
 
 @Getter
@@ -9,11 +10,13 @@ public class UserResponse {
     private final String nickname;
     private final String profileImageUrl;
     private final String role;
+    private String slug;
 
-    public UserResponse(User user) {
+    public UserResponse(User user, UserFestival festival) {
         this.email = user.getEmail();
-        this.nickname = user.getNickname();
         this.profileImageUrl = user.getProfileImageUrl();
         this.role = user.getRole().name();
+        this.nickname = (festival != null) ? festival.getNickname() : null;
+        this.slug = (festival != null) ? festival.getFestivalSlug() : null;
     }
 }

--- a/src/main/java/com/plink/backend/auth/service/AuthService.java
+++ b/src/main/java/com/plink/backend/auth/service/AuthService.java
@@ -6,6 +6,8 @@ import com.plink.backend.auth.dto.SignUpRequest;
 import com.plink.backend.auth.dto.UserResponse;
 import com.plink.backend.commonService.S3Service;
 import com.plink.backend.user.entity.User;
+import com.plink.backend.user.entity.UserFestival;
+import com.plink.backend.user.repository.UserFestivalRepository;
 import com.plink.backend.user.repository.UserRepository;
 import com.plink.backend.user.role.Role;
 import jakarta.servlet.http.HttpSession;
@@ -30,6 +32,7 @@ import java.util.UUID;
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final UserFestivalRepository userFestivalRepository;
     private final PasswordEncoder passwordEncoder;
     private final HttpSession session;
     private final S3Service s3Service;
@@ -37,44 +40,55 @@ public class AuthService {
     @Value("${cloud.aws.s3.base-url}")
     private String s3BaseUrl;
 
-    // 회원가입
+    // 회원가입 (User 생성 + UserFestival에 등록)
     @Transactional
     public UserResponse signUp(SignUpRequest request) throws IOException {
+        String slug = request.getSlug();
+
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new CustomException(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.");
         }
 
-        if (userRepository.existsByNickname(request.getNickname())) {
-            throw new CustomException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+        // 행사 내 닉네임 중복 방지
+        if (userFestivalRepository.existsByFestivalSlugAndNickname(slug, request.getNickname())) {
+            throw new CustomException(HttpStatus.CONFLICT, "이 행사의 닉네임은 이미 사용 중입니다.");
         }
 
+        // 프로필 업로드
         String imageUrl = null;
-        // S3 업로드 실패 시에도 서버 터지지 않게 예외 처리
-        try {
-            if (request.getProfileImage() != null && !request.getProfileImage().isEmpty()) {
+        if (request.getProfileImage() != null && !request.getProfileImage().isEmpty()) {
+            try {
                 String key = s3Service.upload(request.getProfileImage(), "profiles");
                 imageUrl = s3BaseUrl + "/" + key;
+            } catch (Exception e) {
+                log.error("S3 업로드 실패: {}", e.getMessage());
+                throw new IllegalStateException("S3 업로드 실패로 회원가입이 중단되었습니다.");
             }
-        } catch (Exception e) {
-            log.error("S3 업로드 실패: {}", e.getMessage());
-            // 이미지 업로드 실패 시 회원가입 중단 (return null or throw custom exception)
-            throw new IllegalStateException("S3 업로드 실패로 회원가입이 중단되었습니다.");
         }
 
         // 비밀번호 암호화
         String encodedPw = passwordEncoder.encode(request.getPassword());
 
+        // User 생성
         User user = User.builder()
                 .email(request.getEmail())
-                .nickname(request.getNickname())
                 .password(encodedPw)
                 .profileImageUrl(imageUrl)
                 .role(Role.USER)
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        userRepository.save(user);
-        return new UserResponse(user);
+        // UserFestival 생성
+        UserFestival festival = UserFestival.builder()
+                .user(user)
+                .festivalSlug(slug)
+                .nickname(request.getNickname())
+                .joinedAt(LocalDateTime.now())
+                .build();
+
+        user.addFestival(festival); // 양방향 연결
+        userRepository.save(user); // Cascade -> festival도 함께 저장됨
+        return new UserResponse(user, festival);
     }
 
     // 회원 로그인
@@ -88,7 +102,7 @@ public class AuthService {
         }
 
         session.setAttribute("user", user);
-        return new UserResponse(user);
+        return new UserResponse(user, null);
     }
 
     // 로그아웃(세션 무효화)
@@ -99,47 +113,51 @@ public class AuthService {
 
     // 게스트 계정 생성
     @Transactional
-    public UserResponse createGuest(String nickname, MultipartFile profileImage) throws IOException {
+    public UserResponse createGuest(String slug, String nickname, MultipartFile profileImage) throws IOException {
         String guestId = "guest-" + UUID.randomUUID().toString().substring(0, 8);
 
-        // S3 업로드
-        String imageKey = (profileImage != null && !profileImage.isEmpty())
-                ? s3Service.upload(profileImage, "guest-profiles")
-                : null;
-
-        String imageUrl = (imageKey != null)
-                ? s3BaseUrl + "/" + imageKey
-                : "/images/default_guest.png";
-
-        // 닉네임 중복 체크
-        if (userRepository.existsByNickname(nickname)) {
-            throw new CustomException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+        // 행사 내 닉네임 중복 체크
+        if (userFestivalRepository.existsByFestivalSlugAndNickname(slug, nickname)) {
+            throw new CustomException(HttpStatus.CONFLICT, "이 행사의 닉네임은 이미 사용 중입니다.");
         }
 
-        // User 엔티티 생성
+        String imageUrl = null;
+        if (profileImage != null && !profileImage.isEmpty()) {
+            String key = s3Service.upload(profileImage, "guest-profiles");
+            imageUrl = s3BaseUrl + "/" + key;
+        } else {
+            imageUrl = "/images/default_guest.png";
+        }
+
         User guest = User.builder()
                 .email(guestId)
-                .nickname(nickname)
-                .password("")
+                .password("") // 게스트는 비밀번호 없음
                 .profileImageUrl(imageUrl)
                 .role(Role.GUEST)
                 .createdAt(LocalDateTime.now())
                 .expiresAt(LocalDateTime.now().plusHours(24))
                 .build();
 
-        // 정보 저장 및 세션 등록
+        // 게스트용 UserFestival 생성
+        UserFestival festival = UserFestival.builder()
+                .user(guest)
+                .festivalSlug(slug)
+                .nickname(nickname)
+                .joinedAt(LocalDateTime.now())
+                .build();
+
+        guest.addFestival(festival);
+
         userRepository.save(guest);
         session.setAttribute("guest", guest);
 
-        return new UserResponse(guest);
+        return new UserResponse(guest, festival);
     }
 
-
-    // 게스트 -> 회원 데이터 마이그레이션
+    // 게스트 -> 회원 데이터 이전 (임시)
     @Transactional
     public void migrateGuestToUser(String guestId, User user) {
         userRepository.findByEmail(guestId).ifPresent(guest -> {
-            // 여기에 게스트 관련 데이터(예: 점수, 피드 등) 이전 로직 추가 가능
             userRepository.delete(guest);
         });
     }

--- a/src/main/java/com/plink/backend/auth/service/AuthService.java
+++ b/src/main/java/com/plink/backend/auth/service/AuthService.java
@@ -50,7 +50,7 @@ public class AuthService {
         }
 
         // 행사 내 닉네임 중복 방지
-        if (userFestivalRepository.existsByFestivalSlugAndNickname(slug, request.getNickname())) {
+        if (userFestivalRepository.existsByFestivalSlugAndNickname(request.getSlug(), request.getNickname())) {
             throw new CustomException(HttpStatus.CONFLICT, "이 행사의 닉네임은 이미 사용 중입니다.");
         }
 

--- a/src/main/java/com/plink/backend/user/controller/UserController.java
+++ b/src/main/java/com/plink/backend/user/controller/UserController.java
@@ -3,6 +3,8 @@ package com.plink.backend.user.controller;
 import com.plink.backend.auth.dto.UserResponse;
 import com.plink.backend.global.exception.CustomException;
 import com.plink.backend.user.entity.User;
+import com.plink.backend.user.entity.UserFestival;
+import com.plink.backend.user.repository.UserFestivalRepository;
 import com.plink.backend.user.role.Role;
 import com.plink.backend.user.service.UserService;
 import jakarta.servlet.http.HttpSession;
@@ -11,12 +13,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/user")
 @RequiredArgsConstructor
 public class UserController {
 
     private final HttpSession session;
+    private final UserFestivalRepository userFestivalRepository;
 
     @GetMapping("/info")
     public ResponseEntity<UserResponse> getUserInfo() {
@@ -28,11 +33,19 @@ public class UserController {
         }
 
         if (userObj instanceof User user) {
-            return ResponseEntity.ok(new UserResponse(user));
+            // 회원: 가장 최근 참여 행사 정보 조회
+            List<UserFestival> festivals = userFestivalRepository.findByUser_UserId(user.getUserId());
+            UserFestival recentFestival = festivals.isEmpty() ? null : festivals.get(festivals.size() - 1);
+
+            return ResponseEntity.ok(new UserResponse(user, recentFestival));
         }
 
         if (guestObj instanceof User guest) {
-            return ResponseEntity.ok(new UserResponse(guest));
+            // 게스트: slug 1개만 존재하므로 바로 조회
+            List<UserFestival> festivals = userFestivalRepository.findByUser_UserId(guest.getUserId());
+            UserFestival guestFestival = festivals.isEmpty() ? null : festivals.get(0);
+
+            return ResponseEntity.ok(new UserResponse(guest, guestFestival));
         }
 
         throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "세션 정보가 손상되었습니다.");

--- a/src/main/java/com/plink/backend/user/entity/User.java
+++ b/src/main/java/com/plink/backend/user/entity/User.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "users")
@@ -21,10 +23,9 @@ public class User {
     @Column(unique = true)
     private String email; // 회원 이메일 or 게스트 식별자 (guest-xxxx)
 
-    @Column(unique = true)
-    private String nickname;
-
+    @Column(nullable = false)
     private String password;
+
     private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
@@ -32,9 +33,12 @@ public class User {
 
     private LocalDateTime createdAt;
     private LocalDateTime expiresAt; // 게스트 만료 시간 (회원이면 null)
-
     // Soft delete 등 확장 대비용 필드
     private LocalDateTime deletedAt;
+
+    // 회원이 참여한 행사 리스트
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserFestival> festivals = new ArrayList<>();
 
     public boolean isGuestExpired() {
         return role == Role.GUEST && expiresAt != null && expiresAt.isBefore(LocalDateTime.now());
@@ -42,5 +46,10 @@ public class User {
 
     public void extendGuestSession() {
         this.expiresAt = LocalDateTime.now().plusHours(24);
+    }
+
+    public void addFestival(UserFestival festival) {
+        festivals.add(festival);
+        festival.setUser(this);
     }
 }

--- a/src/main/java/com/plink/backend/user/entity/User.java
+++ b/src/main/java/com/plink/backend/user/entity/User.java
@@ -38,6 +38,7 @@ public class User {
 
     // 회원이 참여한 행사 리스트
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<UserFestival> festivals = new ArrayList<>();
 
     public boolean isGuestExpired() {
@@ -49,6 +50,9 @@ public class User {
     }
 
     public void addFestival(UserFestival festival) {
+        if (festivals == null) {
+            festivals = new ArrayList<>();
+        }
         festivals.add(festival);
         festival.setUser(this);
     }

--- a/src/main/java/com/plink/backend/user/entity/UserFestival.java
+++ b/src/main/java/com/plink/backend/user/entity/UserFestival.java
@@ -1,0 +1,38 @@
+package com.plink.backend.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "user_festival",
+        uniqueConstraints = { // 닉네임 중복불가 조합은 slug, nickname으로 구별.
+                @UniqueConstraint(columnNames = {"festival_slug", "nickname"})
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserFestival { // 한 유저는 여러 행사에 참여할 수 있음
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // User와 다대일 관계로 매핑
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "festival_slug", nullable = false)
+    private String festivalSlug;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/com/plink/backend/user/repository/UserFestivalRepository.java
+++ b/src/main/java/com/plink/backend/user/repository/UserFestivalRepository.java
@@ -3,7 +3,11 @@ package com.plink.backend.user.repository;
 import com.plink.backend.user.entity.UserFestival;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserFestivalRepository extends JpaRepository<UserFestival, Long> {
     // 행사(slug) + 닉네임 중복 체크
     boolean existsByFestivalSlugAndNickname(String festivalSlug, String nickname);
+    // 유저의 행사리스트 조회
+    List<UserFestival> findByUser_UserId(Long userId);
 }

--- a/src/main/java/com/plink/backend/user/repository/UserFestivalRepository.java
+++ b/src/main/java/com/plink/backend/user/repository/UserFestivalRepository.java
@@ -1,0 +1,9 @@
+package com.plink.backend.user.repository;
+
+import com.plink.backend.user.entity.UserFestival;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserFestivalRepository extends JpaRepository<UserFestival, Long> {
+    // 행사(slug) + 닉네임 중복 체크
+    boolean existsByFestivalSlugAndNickname(String festivalSlug, String nickname);
+}

--- a/src/main/java/com/plink/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/plink/backend/user/repository/UserRepository.java
@@ -8,5 +8,4 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
-    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/plink/backend/user/service/UserService.java
+++ b/src/main/java/com/plink/backend/user/service/UserService.java
@@ -2,10 +2,14 @@ package com.plink.backend.user.service;
 
 import com.plink.backend.auth.dto.UserResponse;
 import com.plink.backend.user.entity.User;
+import com.plink.backend.user.entity.UserFestival;
+import com.plink.backend.user.repository.UserFestivalRepository;
 import com.plink.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -13,18 +17,42 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserFestivalRepository userFestivalRepository;
 
-    // 이메일로 유저 정보 조회
+    // 이메일로 유저정보 조회, 가장 최근에 참여한 행사정보 반환
     public UserResponse getUserInfoByEmail(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + email));
-        return new UserResponse(user);
+
+        List<UserFestival> festivals = userFestivalRepository.findByUser_UserId(user.getUserId());
+        UserFestival recentFestival = festivals.isEmpty() ? null : festivals.get(festivals.size() - 1);
+
+        return new UserResponse(user, recentFestival);
     }
 
-    // ID 로 유저 정보 조회
+    // ID로 유저정보 조회, 가장 최근에 참여한 행사정보 반환
     public UserResponse getUserInfoById(Long id) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: id=" + id));
-        return new UserResponse(user);
+
+        List<UserFestival> festivals = userFestivalRepository.findByUser_UserId(user.getUserId());
+        UserFestival recentFestival = festivals.isEmpty() ? null : festivals.get(festivals.size() - 1);
+
+        return new UserResponse(user, recentFestival);
+    }
+
+    // 특정 slug 기준으로 유저정보 조회, 한 유저가 여러행사 참여했을 수 있으므로 slug 지정 가능하다!
+    public UserResponse getUserInfoBySlug(Long userId, String slug) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: id=" + userId));
+
+        UserFestival festival = userFestivalRepository
+                .findByUser_UserId(userId)
+                .stream()
+                .filter(f -> f.getFestivalSlug().equals(slug))
+                .findFirst()
+                .orElse(null);
+
+        return new UserResponse(user, festival);
     }
 }


### PR DESCRIPTION
## 📌 이슈번호 및 PR 유형
<!-- closed #이슈번호 -->
closed #15 

---

## PR 유형 
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링(동작 변경 없음)
- [ ] Test: 테스트 코드 추가/수정
- [ ] Chore: 빌드/배포/환경설정 등 잡무

---

## 📝 개요
<!-- 이번 PR에서 어떤 작업을 했는지 간단히 설명 -->
### USER, GUEST에 상관없이, 행사별로 닉네임 중복을 식별할 수 있게 되었다! 
- **UserFestival 엔티티 새로 생성** (User 엔티티와 다대일 관계 -> 한 유저는 여러 축제에 참여할 수 있음. ) 
    - User 엔티티: 회원의 기본 정보
    - UserFestival 엔티티: 회원이 각 행사에서 가지는 nickname, slug, joinedAt 등의 정보 관리 
- 이 변경사항으로 인해 발생하는 오류들 수정 

---

## 🔍 변경 사항
<!-- 주요 변경 내용 리스트 -->
ex) - `UserController`에 로그인 POST 메서드 추가
- AuthService에서의 변경 포인트
    - 회원가입 시 User 저장 후, UserFestival(slug+nickname) 등록
    - **게스트 로그인 시 slug 기반 User + UserFestival 생성**
    - 닉네임 중복 검사는 UserFestivalRepository.existsByFestivalSlugAndNickname() 이용

---

## 📷 스크린샷(선택)
<!-- API 응답 포스트맨 예시 등 -->
기존에는 USER끼리, GUEST끼리만 닉네임이 중복불가로 사용자를 식별했다면, 
**수정사항 : (slug, nickname) 쌍으로 사용자 식별.**

### nickname = userguest, slug = plink2025로 회원가입한 유저가 있다고 하자. 
<img width="1759" height="1344" alt="image" src="https://github.com/user-attachments/assets/bb33dd14-0cbe-4436-bbf3-fca2b65faad4" />

### 만약 같은 nickname과 slug로 게스트 로그인을 하고 싶다면 막아진다! 
<img width="1781" height="1084" alt="image" src="https://github.com/user-attachments/assets/bac94ae3-dc4f-4080-8c02-0b2d33299b63" />

### nickname을 동일하게 하고, slug값을 plink2026으로 수정했더니 게스트 로그인 가능 
<img width="1769" height="1215" alt="image" src="https://github.com/user-attachments/assets/297d0f5c-d054-44ff-83ec-65795f9fbe7d" />

### slug를 동일하게 하고, nickname을 userguest2로 수정했더니 게스트 로그인 가능
<img width="1761" height="1238" alt="image" src="https://github.com/user-attachments/assets/b944ec7c-31ca-44e7-9c92-ba8a67ef4880" />


---

## Review Notes 
리뷰어에게 공유할 중요 사항이 있다면 알려주세요~!

---

## ✅ PR 전 체크리스트
작성하신 코드가 다음의 요구사항을 만족하는지 확인해주세요. 

- [X] 변경 사항에 대한 테스트 여부
- [X] 불필요한 콘솔 로그 제거
