### PR TITLE
Feat: 네컷사진 큐알반환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'me.paulschwarz:spring-dotenv:4.0.0' //.env 자동으로 인식
     implementation 'com.mysql:mysql-connector-j:8.0.33'
+
+    // ZXing 라이브러리 (QR 코드 생성용)
+    implementation 'com.google.zxing:core:3.5.3'
+    implementation 'com.google.zxing:javase:3.5.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/plink/backend/config/SecurityConfig.java
+++ b/src/main/java/com/plink/backend/config/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/auth/**",        // 로그인, 회원가입, 게스트
                                 "/user/info",     // 로그인한 유저 조회용
-                                "/error"           // 오류 페이지 등등
+                                "/error",          // 오류 페이지 등등
+                                "/fourcuts/**"
 
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/{slug}/post", "/{slug}/post/**").permitAll()

--- a/src/main/java/com/plink/backend/fourcuts/controller/FourCutsController.java
+++ b/src/main/java/com/plink/backend/fourcuts/controller/FourCutsController.java
@@ -1,0 +1,23 @@
+package com.plink.backend.fourcuts.controller;
+
+import com.plink.backend.fourcuts.dto.FourCutsResponse;
+import com.plink.backend.fourcuts.service.FourCutsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/fourcuts")
+@RequiredArgsConstructor
+public class FourCutsController {
+
+    private final FourCutsService fourCutsService;
+
+    /**
+     * ✅ 네컷사진 업로드 및 QR 생성
+     */
+    @PostMapping("/upload")
+    public FourCutsResponse uploadFourCut(@RequestParam("file") MultipartFile file) {
+        return fourCutsService.uploadFourCut(file);
+    }
+}

--- a/src/main/java/com/plink/backend/fourcuts/controller/FourCutsController.java
+++ b/src/main/java/com/plink/backend/fourcuts/controller/FourCutsController.java
@@ -13,9 +13,7 @@ public class FourCutsController {
 
     private final FourCutsService fourCutsService;
 
-    /**
-     * ✅ 네컷사진 업로드 및 QR 생성
-     */
+    // 네컷사진 업로드 및 QR 생성
     @PostMapping("/upload")
     public FourCutsResponse uploadFourCut(@RequestParam("file") MultipartFile file) {
         return fourCutsService.uploadFourCut(file);

--- a/src/main/java/com/plink/backend/fourcuts/dto/FourCutsResponse.java
+++ b/src/main/java/com/plink/backend/fourcuts/dto/FourCutsResponse.java
@@ -1,0 +1,11 @@
+package com.plink.backend.fourcuts.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FourCutsResponse {
+    private String imageUrl;
+    private String qrUrl;
+}

--- a/src/main/java/com/plink/backend/fourcuts/service/FourCutsService.java
+++ b/src/main/java/com/plink/backend/fourcuts/service/FourCutsService.java
@@ -10,6 +10,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Service
 @RequiredArgsConstructor
@@ -18,21 +20,39 @@ public class FourCutsService {
     private final S3Service s3Service;
     private final QRCodeUtil qrCodeUtil;
 
-    /**
-     * 네컷사진 업로드 + QR 코드 생성
-     */
     public FourCutsResponse uploadFourCut(MultipartFile file) {
         try {
-            // 1️⃣ 네컷사진을 S3에 업로드
-            S3UploadResult uploadResult = s3Service.upload(file, "fourcuts");
+            /**
+             * ✅ 1️⃣ 파일명 인코딩 처리
+             * - S3Service는 수정하지 않으므로, 여기서 한글 파일명만 미리 안전하게 바꾼 래퍼 MultipartFile을 생성
+             */
+            String encodedName = URLEncoder.encode(file.getOriginalFilename(), StandardCharsets.UTF_8)
+                    .replace("+", "%20");
 
-            // 2️⃣ 이미지 URL 기반으로 QR 코드 생성
-            byte[] qrBytes = qrCodeUtil.generateQRCode(uploadResult.getUrl());
+            MultipartFile encodedFile = new MultipartFile() {
+                @Override public String getName() { return file.getName(); }
+                @Override public String getOriginalFilename() { return encodedName; } // ✅ 수정: 한글 인코딩된 이름
+                @Override public String getContentType() { return file.getContentType(); }
+                @Override public boolean isEmpty() { return file.isEmpty(); }
+                @Override public long getSize() { return file.getSize(); }
+                @Override public byte[] getBytes() throws IOException { return file.getBytes(); }
+                @Override public ByteArrayInputStream getInputStream() throws IOException { return new ByteArrayInputStream(file.getBytes()); }
+                @Override public void transferTo(java.io.File dest) throws IOException { file.transferTo(dest); }
+            };
 
-            // 3️⃣ QR 코드 이미지를 다시 S3에 업로드
+            // ✅ 2️⃣ S3 업로드 (공통 S3Service는 그대로 사용)
+            S3UploadResult uploadResult = s3Service.upload(encodedFile, "fourcuts");
+
+            // ✅ 3️⃣ 업로드된 URL 그대로 QR 생성에 사용
+            String imageUrl = uploadResult.getUrl();
+
+            // 4️⃣ QR 코드 생성
+            byte[] qrBytes = qrCodeUtil.generateQRCode(imageUrl);
+
+            // 5️⃣ QR 코드 파일 업로드
             MultipartFile qrFile = new MultipartFile() {
                 @Override public String getName() { return "qr"; }
-                @Override public String getOriginalFilename() { return "qr_" + file.getOriginalFilename(); }
+                @Override public String getOriginalFilename() { return "qr_" + encodedName; } // ✅ QR 파일명도 안전하게
                 @Override public String getContentType() { return "image/png"; }
                 @Override public boolean isEmpty() { return qrBytes.length == 0; }
                 @Override public long getSize() { return qrBytes.length; }
@@ -45,8 +65,7 @@ public class FourCutsService {
 
             S3UploadResult qrUploadResult = s3Service.upload(qrFile, "fourcuts/qr");
 
-            // 4️⃣ 결과 반환
-            return new FourCutsResponse(uploadResult.getUrl(), qrUploadResult.getUrl());
+            return new FourCutsResponse(imageUrl, qrUploadResult.getUrl());
 
         } catch (Exception e) {
             throw new RuntimeException("네컷사진 업로드 실패: " + e.getMessage(), e);

--- a/src/main/java/com/plink/backend/fourcuts/service/FourCutsService.java
+++ b/src/main/java/com/plink/backend/fourcuts/service/FourCutsService.java
@@ -1,0 +1,55 @@
+package com.plink.backend.fourcuts.service;
+
+import com.plink.backend.commonService.S3Service;
+import com.plink.backend.commonService.S3UploadResult;
+import com.plink.backend.fourcuts.dto.FourCutsResponse;
+import com.plink.backend.fourcuts.util.QRCodeUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class FourCutsService {
+
+    private final S3Service s3Service;
+    private final QRCodeUtil qrCodeUtil;
+
+    /**
+     * 네컷사진 업로드 + QR 코드 생성
+     */
+    public FourCutsResponse uploadFourCut(MultipartFile file) {
+        try {
+            // 1️⃣ 네컷사진을 S3에 업로드
+            S3UploadResult uploadResult = s3Service.upload(file, "fourcuts");
+
+            // 2️⃣ 이미지 URL 기반으로 QR 코드 생성
+            byte[] qrBytes = qrCodeUtil.generateQRCode(uploadResult.getUrl());
+
+            // 3️⃣ QR 코드 이미지를 다시 S3에 업로드
+            MultipartFile qrFile = new MultipartFile() {
+                @Override public String getName() { return "qr"; }
+                @Override public String getOriginalFilename() { return "qr_" + file.getOriginalFilename(); }
+                @Override public String getContentType() { return "image/png"; }
+                @Override public boolean isEmpty() { return qrBytes.length == 0; }
+                @Override public long getSize() { return qrBytes.length; }
+                @Override public byte[] getBytes() { return qrBytes; }
+                @Override public ByteArrayInputStream getInputStream() { return new ByteArrayInputStream(qrBytes); }
+                @Override public void transferTo(java.io.File dest) throws IOException {
+                    throw new UnsupportedOperationException("not used");
+                }
+            };
+
+            S3UploadResult qrUploadResult = s3Service.upload(qrFile, "fourcuts/qr");
+
+            // 4️⃣ 결과 반환
+            return new FourCutsResponse(uploadResult.getUrl(), qrUploadResult.getUrl());
+
+        } catch (Exception e) {
+            throw new RuntimeException("네컷사진 업로드 실패: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/plink/backend/fourcuts/util/QRCodeUtil.java
+++ b/src/main/java/com/plink/backend/fourcuts/util/QRCodeUtil.java
@@ -1,0 +1,29 @@
+package com.plink.backend.fourcuts.util;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.WriterException;
+import com.google.zxing.qrcode.QRCodeWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class QRCodeUtil {
+
+    public byte[] generateQRCode(String content) throws WriterException, IOException {
+        // ✅ URL 내 공백만 안전하게 인코딩하고, 전체 구조는 그대로 유지
+        String safeContent = content.replace(" ", "%20");
+
+        QRCodeWriter writer = new QRCodeWriter();
+        BitMatrix matrix = writer.encode(safeContent, BarcodeFormat.QR_CODE, 300, 300);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        MatrixToImageWriter.writeToStream(matrix, "PNG", outputStream);
+        return outputStream.toByteArray();
+    }
+}

--- a/src/main/java/com/plink/backend/fourcuts/util/QRCodeUtil.java
+++ b/src/main/java/com/plink/backend/fourcuts/util/QRCodeUtil.java
@@ -16,11 +16,9 @@ import java.nio.charset.StandardCharsets;
 public class QRCodeUtil {
 
     public byte[] generateQRCode(String content) throws WriterException, IOException {
-        // ✅ URL 내 공백만 안전하게 인코딩하고, 전체 구조는 그대로 유지
-        String safeContent = content.replace(" ", "%20");
-
+        // ✅ 수정 없음: URL을 그대로 QR에 사용 (이미 인코딩 완료 상태)
         QRCodeWriter writer = new QRCodeWriter();
-        BitMatrix matrix = writer.encode(safeContent, BarcodeFormat.QR_CODE, 300, 300);
+        BitMatrix matrix = writer.encode(content.trim(), BarcodeFormat.QR_CODE, 300, 300);
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         MatrixToImageWriter.writeToStream(matrix, "PNG", outputStream);

--- a/src/main/java/com/plink/backend/fourcuts/util/QRCodeUtil.java
+++ b/src/main/java/com/plink/backend/fourcuts/util/QRCodeUtil.java
@@ -16,7 +16,7 @@ import java.nio.charset.StandardCharsets;
 public class QRCodeUtil {
 
     public byte[] generateQRCode(String content) throws WriterException, IOException {
-        // ✅ 수정 없음: URL을 그대로 QR에 사용 (이미 인코딩 완료 상태)
+        // URL을 그대로 QR에 사용 (이미 인코딩 완료 상태이기 때문!)
         QRCodeWriter writer = new QRCodeWriter();
         BitMatrix matrix = writer.encode(content.trim(), BarcodeFormat.QR_CODE, 300, 300);
 


### PR DESCRIPTION
## 📌 이슈번호 및 PR 유형
<!-- closed #이슈번호 -->
closed #19 

---

## PR 유형 
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링(동작 변경 없음)
- [ ] Test: 테스트 코드 추가/수정
- [ ] Chore: 빌드/배포/환경설정 등 잡무

---

## 📝 개요
<!-- 이번 PR에서 어떤 작업을 했는지 간단히 설명 -->
프론트로부터 네컷사진을 받으면, 사진을 S3에 저장하여 QR로 변환 후 QR 이미지를 반환합니다.

---

## 🔍 변경 사항
<!-- 주요 변경 내용 리스트 -->
- 구글의 ZXing 라이브러리를 사용하여 QR코드를 생성하도록 했습니다. (-> build.gradle에 의존성 추가함)
- file 변수로 이미지 파일을 받으면, imageUrl 변수로 이미지의 S3버킷 링크를, qrUrl 변수로 QR코드의 S3버킷 링크를 반환합니다.
- 버킷에 업로드된 이미지는 /fourcuts 폴더에 저장되며, QR코드는 /fourcuts/qr 디렉터리에 저장됩니다. 

---

## 📷 스크린샷(선택)
<!-- API 응답 포스트맨 예시 등 -->
<img width="1749" height="1051" alt="image" src="https://github.com/user-attachments/assets/b135e277-6866-4438-b8b9-416d4c126187" />

아래 qrUrl의 경로로 접근하면 다음과 같은 큐알코드가 뜨게 됩니다.
<img width="598" height="610" alt="image" src="https://github.com/user-attachments/assets/b24091b2-0635-4bd5-bb34-b4f49155d4de" />

큐알코드를 스캔하면 원본 이미지가 나옵니다.
원본 이미지는 imageUrl의 경로로 접근했을 때 나오는 이미지와 동일합니다. (당연)

---

## Review Notes 
리뷰어에게 공유할 중요 사항이 있다면 알려주세요~!

---

## ✅ PR 전 체크리스트
작성하신 코드가 다음의 요구사항을 만족하는지 확인해주세요. 

- [x] 변경 사항에 대한 테스트 여부
- [x] 불필요한 콘솔 로그 제거
