### PR TITLE
Feat: 이미지 수정 관려

### DIFF
--- a/src/main/java/com/plink/backend/feed/controller/CommentController.java
+++ b/src/main/java/com/plink/backend/feed/controller/CommentController.java
@@ -40,7 +40,7 @@ public class CommentController {
     }
 
     // 댓글 수정
-    @PutMapping("/comment/{commentId}")
+    @PatchMapping("/comment/{commentId}")
     public ResponseEntity<CommentResponse> updateComment(
             @PathVariable String slug,
             @PathVariable Long commentId,

--- a/src/main/java/com/plink/backend/feed/controller/ImageController.java
+++ b/src/main/java/com/plink/backend/feed/controller/ImageController.java
@@ -1,0 +1,50 @@
+package com.plink.backend.feed.controller;
+
+import com.plink.backend.commonService.S3Service;
+import com.plink.backend.feed.dto.post.PostDetailResponse;
+import com.plink.backend.feed.entity.Image;
+import com.plink.backend.feed.entity.Post;
+import com.plink.backend.feed.repository.ImageRepository;
+import com.plink.backend.feed.repository.PostRepository;
+import com.plink.backend.feed.service.ImageService;
+import com.plink.backend.feed.service.PostService;
+import com.plink.backend.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("{slug}/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+    private final PostRepository postRepository;
+
+    /** 게시글 이미지 업로드 */
+    @PostMapping("/{postId}")
+    public ResponseEntity<PostDetailResponse> uploadImages(
+            @PathVariable Long postId,
+            @RequestParam("images") List<MultipartFile> files
+    ) throws IOException  {
+        imageService.saveImages(postId, files);
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."));
+
+        return ResponseEntity.ok(PostDetailResponse.from(post));
+    }
+
+    /** ✅ 게시글 이미지 삭제 */
+    @DeleteMapping("/{imageId}")
+    public ResponseEntity<PostDetailResponse> deleteImage(@PathVariable Long imageId) {
+        Post post = imageService.deleteImageAndReturnPost(imageId);
+        return ResponseEntity.ok(PostDetailResponse.from(post));
+    }
+}

--- a/src/main/java/com/plink/backend/feed/controller/PostController.java
+++ b/src/main/java/com/plink/backend/feed/controller/PostController.java
@@ -58,7 +58,8 @@ public class PostController {
     public ResponseEntity<PostDetailResponse> updatePost(
             @PathVariable String slug,
             @PathVariable Long postId,
-            @ModelAttribute PostUpdateRequest request) {
+            @ModelAttribute PostUpdateRequest request) throws IOException {
+
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || !authentication.isAuthenticated()) {

--- a/src/main/java/com/plink/backend/feed/dto/post/PostDetailResponse.java
+++ b/src/main/java/com/plink/backend/feed/dto/post/PostDetailResponse.java
@@ -30,7 +30,7 @@ public class PostDetailResponse {
     private String tagName;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private List<String> imageUrls;           // S3에서 변환된 URL
+    private List<ImageInfo> images;          // S3에서 변환된 URL
     private List<CommentResponse> comments; // 댓글 리스트
     private int commentCount;
     private int likeCount;
@@ -52,9 +52,9 @@ public class PostDetailResponse {
                 .postType(post.getPostType().toString())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
-                .imageUrls(post.getImages() == null ? List.of() :
+                .images(post.getImages() == null ? List.of() :
                         post.getImages().stream()
-                                .map(Image::getImage_url)
+                                .map(img -> new ImageInfo(img.getId(), img.getImageUrl()))
                                 .collect(Collectors.toList()))
                 .comments(post.getComments() == null ? List.of() :
                         post.getComments().stream()
@@ -82,14 +82,28 @@ public class PostDetailResponse {
                 .tagName(post.getTag().getTag_name())
                 .poll(pollResponse)
                 .createdAt(post.getCreatedAt())
+                .images(post.getImages() == null ? List.of() :
+                        post.getImages().stream()
+                                .map(img -> new ImageInfo(img.getId(), img.getImageUrl()))
+                                .collect(Collectors.toList()))
                 .comments(
                         post.getComments() == null ? List.of() :
                                 post.getComments().stream()
                                         .filter(c -> hiddenCommentIds == null || !hiddenCommentIds.contains(c.getId()))
                                         .map(CommentResponse::from)
                                         .collect(Collectors.toList())
+
                 )
+                .commentCount(post.getCommentCount())
+                .likeCount(post.getLikeCount())
                 .build();
     }
 
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ImageInfo {
+        private Long id;
+        private String imageUrl;
+    }
 }

--- a/src/main/java/com/plink/backend/feed/dto/post/PostResponse.java
+++ b/src/main/java/com/plink/backend/feed/dto/post/PostResponse.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.plink.backend.feed.dto.poll.PollResponse;
 import com.plink.backend.feed.entity.Image;
 import com.plink.backend.feed.entity.Post;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
@@ -27,7 +29,7 @@ public class PostResponse {
     private String tagName;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private List<String> imageUrls;
+    private List<ImageInfo> images;
     private int commentCount;
     private int likeCount;
     private PollResponse poll;
@@ -44,14 +46,22 @@ public class PostResponse {
                 .tagName(post.getTag().getTag_name())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
-                .imageUrls(post.getImages() == null ? List.of() :
+                .images(post.getImages() == null ? List.of() :
                         post.getImages().stream()
-                                .map(Image::getImage_url)
+                                .map(img -> new PostResponse.ImageInfo(img.getId(), img.getImageUrl()))
                                 .collect(Collectors.toList()))
                 .commentCount(post.getCommentCount())
                 .likeCount(post.getLikeCount())
                 .poll(post.getPoll() == null ? null : PollResponse.from(post.getPoll(), null))
                 .build();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ImageInfo {
+        private Long id;
+        private String imageUrl;
     }
 
     @Getter
@@ -72,3 +82,4 @@ public class PostResponse {
         }
     }
 }
+

--- a/src/main/java/com/plink/backend/feed/dto/post/PostUpdateRequest.java
+++ b/src/main/java/com/plink/backend/feed/dto/post/PostUpdateRequest.java
@@ -1,6 +1,9 @@
 package com.plink.backend.feed.dto.post;
 
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -12,4 +15,5 @@ public class PostUpdateRequest {
     private String title;
     private String content;
     private Long tagId;
+
 }

--- a/src/main/java/com/plink/backend/feed/entity/Image.java
+++ b/src/main/java/com/plink/backend/feed/entity/Image.java
@@ -17,7 +17,9 @@ public class Image {
     @Column(nullable = false)
     private String s3key;
     private String originalName;
-    private String image_url;
+
+    @Column(name = "image_url")
+    private String imageUrl;
 
     @ManyToOne(fetch= FetchType.LAZY)
     @JoinColumn(name="post_id")

--- a/src/main/java/com/plink/backend/feed/repository/ImageRepository.java
+++ b/src/main/java/com/plink/backend/feed/repository/ImageRepository.java
@@ -4,5 +4,9 @@ import com.plink.backend.feed.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface ImageRepository extends JpaRepository<Image, Long> { }
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+}

--- a/src/main/java/com/plink/backend/feed/service/ImageService.java
+++ b/src/main/java/com/plink/backend/feed/service/ImageService.java
@@ -1,0 +1,83 @@
+package com.plink.backend.feed.service;
+
+import com.plink.backend.commonService.S3Service;
+import com.plink.backend.commonService.S3UploadResult;
+import com.plink.backend.feed.entity.Image;
+import com.plink.backend.feed.entity.Post;
+import com.plink.backend.feed.repository.ImageRepository;
+import com.plink.backend.feed.repository.PostRepository;
+import com.plink.backend.global.exception.CustomException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ImageService {
+
+    private final ImageRepository imageRepository;
+    private final PostRepository postRepository;
+    private final S3Service s3Service;
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /** 이미지 업로드 (3장 제한 포함) */
+    public List<Image> saveImages(Long postId, List<MultipartFile> files) throws IOException {
+        if (files == null || files.isEmpty()) return new ArrayList<>();
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."));
+
+        if (post.getImages().size() + files.size() > 3) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "이미지는 최대 3장까지 업로드할 수 있습니다.");
+        }
+
+        List<Image> savedImages = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            S3UploadResult uploadResult = s3Service.upload(file, "posts");
+            Image image = Image.builder()
+                    .post(post)
+                    .s3key(uploadResult.getKey())
+                    .originalName(uploadResult.getOriginalFilename())
+                    .imageUrl(uploadResult.getUrl())
+                    .build();
+            imageRepository.save(image);
+            savedImages.add(image);
+        }
+
+
+        imageRepository.flush();       // 🟩 DB에 즉시 반영
+        entityManager.refresh(post);
+
+        return savedImages;
+    }
+
+    /** 게시글 이미지 삭제 + 게시글 반환 */
+    public Post deleteImageAndReturnPost(Long imageId) {
+        Image image = imageRepository.findById(imageId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."));
+
+        Post post = image.getPost();
+
+        // S3 삭제
+        s3Service.delete(image.getS3key());
+
+        // DB 삭제
+        imageRepository.delete(image);
+
+        // 엔티티 갱신
+        post.getImages().removeIf(img -> img.getId().equals(imageId));
+
+        return post;
+    }
+}

--- a/src/main/java/com/plink/backend/feed/service/PostService.java
+++ b/src/main/java/com/plink/backend/feed/service/PostService.java
@@ -45,12 +45,13 @@ public class PostService {
     private final UserFestivalRepository userFestivalRepository;
     private final HiddenContentRepository hiddenContentRepository;
     private final PollService pollService;
+    private final ImageService imageService;
     private final UserService userService;
 
     @Transactional
     // 게시글 작성하기
 
-    public Post createPost(User author, PostCreateRequest request, String slug) throws IOException {
+    public Post createPost(User author, PostCreateRequest request, String slug)  throws IOException {
 
         // 행사 검증
         Festival festival = festivalRepository.findBySlug(slug)
@@ -69,11 +70,6 @@ public class PostService {
         if (request.getPostType() == PostType.NORMAL &&
                 (request.getContent() == null || request.getContent().isBlank())) {
             throw new IllegalArgumentException("게시글의 내용은 비워둘 수 없습니다.");
-        }
-
-        // 이미지 개수 검증
-        if (request.getImages() != null && request.getImages().size() > 3) {
-            throw new IllegalArgumentException("이미지는 최대 3장까지 업로드 가능합니다.");
         }
 
         // Post 생성 및 1차 저장
@@ -96,20 +92,8 @@ public class PostService {
             postRepository.save(post);
         }
 
-        // 이미지 업로드 처리
         if (request.getImages() != null && !request.getImages().isEmpty()) {
-            for (MultipartFile file : request.getImages()) {
-                S3UploadResult uploadResult = s3Service.upload(file, "posts");
-
-                Image image = Image.builder()
-                        .post(post)
-                        .s3key(uploadResult.getKey())
-                        .originalName(uploadResult.getOriginalFilename())
-                        .image_url(uploadResult.getUrl())
-                        .build();
-
-                post.getImages().add(image);
-            }
+            imageService.saveImages(post.getId(), request.getImages());
         }
 
         // 최종 저장
@@ -118,7 +102,7 @@ public class PostService {
 
     // 게시글 수정
     @Transactional
-    public Post updatePost(User author,PostUpdateRequest request,Long postId){
+    public Post updatePost(User author,PostUpdateRequest request,Long postId)throws IOException {
         Post post = postRepository.findById(postId)
                 .orElseThrow(()->new IllegalArgumentException("게시글을 찾을 수 없습니다."));
 
@@ -143,6 +127,7 @@ public class PostService {
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 태그입니다."));
             post.updateTag(tag);
         }
+
 
         return post;
     }


### PR DESCRIPTION
## 📌 이슈번호 및 PR 유형
<!-- closed #이슈번호 -->
closed #32 
---

## PR 유형 
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [x] Refactor: 리팩토링(동작 변경 없음)
- [ ] Test: 테스트 코드 추가/수정
- [ ] Chore: 빌드/배포/환경설정 등 잡무

---

## 📝 개요
<!-- 이번 PR에서 어떤 작업을 했는지 간단히 설명 -->
- 게시글 이미지 수정 관련 로직 작업을 했습니다.
- 원래 하나의 수정 API에서 모든 수정을 다 하고 싶었는데, 이미지 관련 로직을 넣으려고 하니 여러가지 문제가 많아서.. 게시글을 수정하는 경우 이미지의 추가, 삭제는 별개의 엔드포인트로 분리하였습니다..


---

## 📷 스크린샷(선택)
<!-- API 응답 포스트맨 예시 등 -->
- 이미지 추가하는 경우 (slug/images/{postId})
<img width="1375" height="848" alt="image" src="https://github.com/user-attachments/assets/3f50a3fa-9562-4e4d-b2d1-ad20e5a681f7" />

- 이미지 삭제하는 경우 (slug/imagse/{lmageId})
<img width="1441" height="885" alt="image" src="https://github.com/user-attachments/assets/c1e31d5f-e05c-4329-b0f4-e406c94516d1" />

---

## Review Notes 
리뷰어에게 공유할 중요 사항이 있다면 알려주세요~!
이미지를 삭제하려면 이미지 아이디가 필요해서 게시글을 반환할 때 이미지가 있는 경우 아이디도 같이 반환하도록 수정했습니다!

너무햄드네요........................................................언제끝나냐 ㅜㅜ
---

## ✅ PR 전 체크리스트
작성하신 코드가 다음의 요구사항을 만족하는지 확인해주세요. 

- [ ] 변경 사항에 대한 테스트 여부
- [ ] 불필요한 콘솔 로그 제거
