### PR TITLE
52 feature 신고한 게시글 상세조회도 안되게 하기

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,14 +14,6 @@ jobs:
 
     env:
       SPRING_PROFILES_ACTIVE: prod
-      DB_HOST: ${{ secrets.DB_HOST }}
-      DB_PORT: ${{ secrets.DB_PORT }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      DB_USERNAME: ${{ secrets.DB_USERNAME }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      S3_BUCKET: ${{ secrets.S3_BUCKET }}
-      S3_BASE_URL: ${{ secrets.S3_BASE_URL }}
-      S3_REGION: ${{ secrets.S3_REGION }}
 
     steps:
       # 1️⃣ 리포지토리 코드 체크아웃
@@ -67,15 +59,26 @@ jobs:
             echo "✅ 현재 디렉토리 확인:" && pwd
             echo "✅ 파일 목록:" && ls -lh
 
+            echo "🧹 기존 컨테이너 정리..."
             docker stop myapp || true
             docker rm myapp || true
             docker rmi myapp:latest || true
 
-            echo "✅ Docker 빌드 시작..."
+            echo "🐳 Docker 빌드 시작..."
             docker build -t myapp .
 
-            echo "✅ 컨테이너 실행..."
-            docker run -d -p 8080:8080 --name myapp --restart always myapp
+            echo "🚀 새 컨테이너 실행..."
+            docker run -d -p 8080:8080 --name myapp --restart always \
+              -e SPRING_PROFILES_ACTIVE=prod \
+              -e DB_HOST='${{ secrets.DB_HOST }}' \
+              -e DB_PORT='${{ secrets.DB_PORT }}' \
+              -e DB_NAME='${{ secrets.DB_NAME }}' \
+              -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \
+              -e DB_PASSWORD='${{ secrets.DB_PASSWORD }}' \
+              -e S3_BUCKET='${{ secrets.S3_BUCKET }}' \
+              -e S3_BASE_URL='${{ secrets.S3_BASE_URL }}' \
+              -e S3_REGION='${{ secrets.S3_REGION }}' \
+              myapp
 
             echo "✅ 실행 중인 컨테이너 확인:"
             docker ps -a

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,16 +68,16 @@ jobs:
             docker build -t myapp .
 
             echo "🚀 새 컨테이너 실행..."
-            docker run -d -p 8080:8080 --name myapp --restart always \
+            docker run -d --network host --name myapp --restart always \
               -e SPRING_PROFILES_ACTIVE=prod \
-              -e DB_HOST='${{ secrets.DB_HOST }}' \
-              -e DB_PORT='${{ secrets.DB_PORT }}' \
-              -e DB_NAME='${{ secrets.DB_NAME }}' \
-              -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \
-              -e DB_PASSWORD='${{ secrets.DB_PASSWORD }}' \
-              -e S3_BUCKET='${{ secrets.S3_BUCKET }}' \
-              -e S3_BASE_URL='${{ secrets.S3_BASE_URL }}' \
-              -e S3_REGION='${{ secrets.S3_REGION }}' \
+              -e DB_HOST=${{ secrets.DB_HOST }} \
+              -e DB_PORT=${{ secrets.DB_PORT }} \
+              -e DB_NAME=${{ secrets.DB_NAME }} \
+              -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
+              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+              -e S3_BUCKET=${{ secrets.S3_BUCKET }} \
+              -e S3_BASE_URL=${{ secrets.S3_BASE_URL }} \
+              -e S3_REGION=${{ secrets.S3_REGION }} \
               myapp
 
             echo "✅ 실행 중인 컨테이너 확인:"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-# Java 17 기반 이미지 사용
 FROM eclipse-temurin:17-jdk-jammy
 
-# 빌드된 JAR 파일을 컨테이너 내부로 복사
-ARG JAR_FILE=*.jar
+# JAR 파일 경로 지정
+ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
-# 컨테이너 실행 시 JAR 실행
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+# 컨테이너 실행 시 jar 실행
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
 # 컨테이너 실행 시 jar 실행
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar", "--spring.profiles.active=prod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Java 17 기반 이미지 사용
-FROM openjdk:17-jdk-slim-bullseye
+FROM eclipse-temurin:17-jdk-jammy
 
 # 빌드된 JAR 파일을 컨테이너 내부로 복사
 ARG JAR_FILE=*.jar

--- a/src/main/java/com/plink/backend/feed/controller/CommentController.java
+++ b/src/main/java/com/plink/backend/feed/controller/CommentController.java
@@ -18,13 +18,13 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/{slug}/post")
+@RequestMapping("/{slug}/posst")
 public class CommentController {
 
     private final CommentService commentService;
 
     // 댓글 작성
-    @PostMapping("/{postId}/comment")
+    @PostMapping("/{postId}/comments")
     public ResponseEntity<CommentResponse> createComment(
             @PathVariable String slug,
             @PathVariable Long postId,
@@ -40,7 +40,7 @@ public class CommentController {
     }
 
     // 댓글 수정
-    @PatchMapping("/comment/{commentId}")
+    @PatchMapping("/comments/{commentId}")
     public ResponseEntity<CommentResponse> updateComment(
             @PathVariable String slug,
             @PathVariable Long commentId,
@@ -61,7 +61,7 @@ public class CommentController {
     }
 
     // 게시글별 댓글 조회
-    @GetMapping("/{postId}/comment")
+    @GetMapping("/{postId}/comments")
     public ResponseEntity<List<CommentResponse>> getComments(
             @PathVariable String slug,
             @PathVariable Long postId) {
@@ -70,7 +70,7 @@ public class CommentController {
 
 
     // 댓글 삭제
-    @DeleteMapping("/comment/{commentId}")
+    @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<Void> deleteComment(
             @PathVariable String slug,
             @PathVariable Long commentId)

--- a/src/main/java/com/plink/backend/feed/controller/CommentLikeController.java
+++ b/src/main/java/com/plink/backend/feed/controller/CommentLikeController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/{slug}/comment")
+@RequestMapping("/{slug}/comments")
 public class CommentLikeController {
 
     private final CommentLikeService CommentLikeService;

--- a/src/main/java/com/plink/backend/feed/controller/PollController.java
+++ b/src/main/java/com/plink/backend/feed/controller/PollController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/{slug}/poll")
+@RequestMapping("/{slug}/polls")
 public class PollController {
 
     private final PollService pollService;

--- a/src/main/java/com/plink/backend/feed/controller/PostController.java
+++ b/src/main/java/com/plink/backend/feed/controller/PostController.java
@@ -1,12 +1,16 @@
 package com.plink.backend.feed.controller;
 
 import com.plink.backend.feed.dto.post.PostResponse;
+import com.plink.backend.feed.entity.ReportTargetType;
+import com.plink.backend.feed.repository.HiddenContentRepository;
 import com.plink.backend.user.entity.User;
 import com.plink.backend.feed.dto.post.PostCreateRequest;
 import com.plink.backend.feed.dto.post.PostDetailResponse;
 import com.plink.backend.feed.dto.post.PostUpdateRequest;
 import com.plink.backend.feed.entity.Post;
 import com.plink.backend.feed.service.PostService;
+import com.plink.backend.user.entity.UserFestival;
+import com.plink.backend.user.repository.UserFestivalRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +30,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.io.IOException;
+import java.util.List;
 
 
 @Slf4j
@@ -34,6 +39,8 @@ import java.io.IOException;
 @RequestMapping("/{slug}/posts")
 public class PostController {
     private final PostService postService;
+    private final HiddenContentRepository hiddenContentRepository;
+    private final UserFestivalRepository userFestivalRepository;
 
     // 게시글 작성 (POST 요청)
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -69,7 +76,20 @@ public class PostController {
         User user = (User) authentication.getPrincipal();
 
         Post updated = postService.updatePost(user, request, postId);
-        PostDetailResponse response = PostDetailResponse.from(updated);
+
+        List<Long> hiddenCommentIds = List.of();
+        if (user != null) {
+            UserFestival userFestival = userFestivalRepository
+                    .findByUser_UserIdAndFestivalSlug(user.getUserId(), slug)
+                    .orElse(null);
+
+            if (userFestival != null) {
+                hiddenCommentIds = hiddenContentRepository
+                        .findTargetIdsByUserFestivalAndTargetType(userFestival, ReportTargetType.COMMENT);
+            }
+        }
+
+        PostDetailResponse response = PostDetailResponse.from(updated, hiddenCommentIds);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
@@ -101,28 +121,19 @@ public class PostController {
 
 
 
-    // 게시판별 전체 조회
+    // 게시판별 전체 조회 + 검색
     @GetMapping
     public ResponseEntity<PostResponse.SliceResult> getPostListByTag(
             @AuthenticationPrincipal User user,
             @PathVariable String slug,
             @RequestParam(required = false) String tag,
+            @RequestParam(required = false) String keyword,
             @PageableDefault(size = 20) Pageable pageable) {
 
-        PostResponse.SliceResult result = postService.getPostListByTag(user, slug, pageable, tag);
+        PostResponse.SliceResult result = postService.getPostListByTag(user, slug, pageable, tag, keyword);
         return ResponseEntity.ok(result);
 
     }
 
-    // 게시판 검색
-    @GetMapping("/search")
-    public ResponseEntity<PostResponse.SliceResult> searchPosts(
-            @PathVariable String slug,
-            @RequestParam(required = false) String q,
-            @RequestParam(required = false) String tag,
-            @PageableDefault(size = 20) Pageable pageable) {
 
-        PostResponse.SliceResult result = postService.searchPostsBySlug(slug, q, tag, pageable);
-        return ResponseEntity.ok(result);
-    }
 }

--- a/src/main/java/com/plink/backend/feed/controller/PostLikeController.java
+++ b/src/main/java/com/plink/backend/feed/controller/PostLikeController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/{slug}/post")
+@RequestMapping("/{slug}/posts")
 public class PostLikeController {
 
     private final PostLikeService postLikeService;

--- a/src/main/java/com/plink/backend/feed/dto/post/PostDetailResponse.java
+++ b/src/main/java/com/plink/backend/feed/dto/post/PostDetailResponse.java
@@ -32,6 +32,7 @@ public class PostDetailResponse {
     private LocalDateTime updatedAt;
     private List<ImageInfo> images;          // S3에서 변환된 URL
     private List<CommentResponse> comments; // 댓글 리스트
+    private List<Long> hiddenCommentIds;
     private int commentCount;
     private int likeCount;
 
@@ -39,9 +40,17 @@ public class PostDetailResponse {
     @Nullable
     private PollResponse poll;
 
-    // 엔티티 -> DTO 변환 편의 메서드
     // 게시글 상세보기
+
     public static PostDetailResponse from(Post post) {
+        return from(post, List.of());
+    }
+    public static PostDetailResponse from(Post post, List<Long> hiddenCommentIds) {
+        List<CommentResponse> visibleComments = post.getComments().stream()
+                .filter(comment -> !hiddenCommentIds.contains(comment.getId()))
+                .map(CommentResponse::from)
+                .collect(Collectors.toList());
+
         return PostDetailResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -56,10 +65,7 @@ public class PostDetailResponse {
                         post.getImages().stream()
                                 .map(img -> new ImageInfo(img.getId(), img.getImageUrl()))
                                 .collect(Collectors.toList()))
-                .comments(post.getComments() == null ? List.of() :
-                        post.getComments().stream()
-                                .map(CommentResponse::from)
-                                .collect(Collectors.toList()))
+                .comments(visibleComments)
                 .commentCount(post.getCommentCount())
                 .likeCount(post.getLikeCount())
                 .build();

--- a/src/main/java/com/plink/backend/feed/entity/ReportTargetType.java
+++ b/src/main/java/com/plink/backend/feed/entity/ReportTargetType.java
@@ -1,5 +1,7 @@
 package com.plink.backend.feed.entity;
 
 public enum ReportTargetType {
-    POST, COMMENT
+    POST,
+    COMMENT,
+    POLL
 }

--- a/src/main/java/com/plink/backend/feed/repository/PostRepository.java
+++ b/src/main/java/com/plink/backend/feed/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.plink.backend.feed.repository;
 
 import com.plink.backend.feed.entity.Post;
+import com.plink.backend.feed.entity.PostType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -30,7 +31,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%'))
       )
       AND (COALESCE(:hiddenIds, NULL) IS NULL OR p.id NOT IN :hiddenIds)
-    ORDER BY p.createdAt DESC
+    ORDER BY p.createdAt ASC 
 """)
     Slice<Post> findPostsFiltered(
             @Param("slug") String slug,
@@ -66,10 +67,19 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
 
     // 인기글
-    @Query("SELECT p FROM Post p WHERE p.festival.slug = :slug " +
-            "ORDER BY (p.likeCount + p.commentCount) DESC, p.createdAt DESC")
-    List<Post> findPopularPostsBySlug(@Param("slug") String slug, Pageable pageable);
-
+    @Query("""
+    SELECT p FROM Post p
+    WHERE p.festival.slug = :slug
+      AND (:postType IS NULL OR p.postType = :postType)
+      AND (COALESCE(:hiddenIds, NULL) IS NULL OR p.id NOT IN :hiddenIds)
+    ORDER BY (p.likeCount + p.commentCount) ASC , p.createdAt ASC 
+""")
+    List<Post> findPopularPosts(
+            @Param("slug") String slug,
+            @Param("postType") PostType postType,
+            @Param("hiddenIds") List<Long> hiddenIds,
+            Pageable pageable
+    );
 
 
 

--- a/src/main/java/com/plink/backend/feed/repository/PostRepository.java
+++ b/src/main/java/com/plink/backend/feed/repository/PostRepository.java
@@ -18,21 +18,30 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @EntityGraph(attributePaths = {"images"})
     Optional<Post> findById(Long id);
 
-    // 전체 게시글 (slug 기준)
-    @Query("SELECT p FROM Post p WHERE p.festival.slug = :slug ORDER BY p.createdAt ASC")
-    Slice<Post> findAllByFestivalSlugOrderByCreatedAtAsc(
-            @Param("slug") String slug,
-            Pageable pageable
-    );
-
-    // 태그 이름으로 필터링 (slug + tag_name)
-    @Query("SELECT p FROM Post p WHERE p.festival.slug = :slug AND p.tag.tag_name = :tagName ORDER BY p.createdAt ASC")
-    Slice<Post> findAllByFestivalSlugAndTag_Tag_nameOrderByCreatedAtAsc(
+    // 전체 게시글 (slug + tag_name + keyword + hiddenId 기준)
+    @Query("""
+    SELECT p
+    FROM Post p
+    WHERE p.festival.slug = :slug
+      AND (:tagName IS NULL OR p.tag.tag_name = :tagName)
+      AND (
+            :keyword IS NULL OR
+            LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+            LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%'))
+      )
+      AND (COALESCE(:hiddenIds, NULL) IS NULL OR p.id NOT IN :hiddenIds)
+    ORDER BY p.createdAt DESC
+""")
+    Slice<Post> findPostsFiltered(
             @Param("slug") String slug,
             @Param("tagName") String tagName,
+            @Param("keyword") String keyword,
+            @Param("hiddenIds") List<Long> hiddenIds,
             Pageable pageable
     );
 
+
+    // 내가 쓴 글 보기
     @EntityGraph(attributePaths = {
             "author.user",
             "tag",
@@ -43,22 +52,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     })
     List<Post> findByAuthor_User_UserId(Long userId);
 
-    // 숨김 제외 (slug 기준)
-    @Query("SELECT p FROM Post p WHERE p.festival.slug = :slug AND p.id NOT IN :ids ORDER BY p.createdAt ASC")
-    Slice<Post> findAllByFestivalSlugAndIdNotInOrderByCreatedAtAsc(
-            @Param("slug") String slug,
-            @Param("ids") List<Long> ids,
-            Pageable pageable
-    );
 
-    // 숨김 제외 + 태그 이름 필터링
-    @Query("SELECT p FROM Post p WHERE p.festival.slug = :slug AND p.tag.tag_name = :tagName AND p.id NOT IN :ids ORDER BY p.createdAt ASC")
-    Slice<Post> findAllByFestivalSlugAndTag_Tag_nameAndIdNotInOrderByCreatedAtAsc(
-            @Param("slug") String slug,
-            @Param("tagName") String tagName,
-            @Param("ids") List<Long> ids,
-            Pageable pageable
-    );
 
     // 상세 조회
     @EntityGraph(attributePaths = {
@@ -76,22 +70,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "ORDER BY (p.likeCount + p.commentCount) DESC, p.createdAt DESC")
     List<Post> findPopularPostsBySlug(@Param("slug") String slug, Pageable pageable);
 
-    // 제목 또는 내용에 검색어가 포함
-    @Query("SELECT p FROM Post p WHERE p.festival.slug = :slug " +
-            "AND (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
-            "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')))")
-    Slice<Post> searchBySlugAndKeyword(@Param("slug") String slug,
-                                       @Param("keyword") String keyword,
-                                       Pageable pageable);
-    // 태그로 필터링 + 검색어
-    @Query("SELECT p FROM Post p WHERE p.festival.slug = :slug " +
-            "AND p.tag.tag_name = :tagName " +
-            "AND (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
-            "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')))")
-    Slice<Post> searchBySlugAndTagAndKeyword(@Param("slug") String slug,
-                                             @Param("tagName") String tagName,
-                                             @Param("keyword") String keyword,
-                                             Pageable pageable);
 
 
 

--- a/src/main/java/com/plink/backend/main/controller/MainController.java
+++ b/src/main/java/com/plink/backend/main/controller/MainController.java
@@ -1,15 +1,19 @@
 package com.plink.backend.main.controller;
 
 import com.plink.backend.feed.dto.post.PostResponse;
+import com.plink.backend.main.dto.MainResponse;
 import com.plink.backend.main.service.MainService;
+import com.plink.backend.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,9 +22,13 @@ public class MainController {
 
     private final MainService mainService;
 
-    // 인기글 top3 조회
+    // 인기글 조회
     @GetMapping("/popular")
-    public ResponseEntity<List<PostResponse>> getPopularPosts(@PathVariable String slug) {
-        return ResponseEntity.ok(mainService.getPopularPosts(slug));
+    public ResponseEntity<MainResponse> getPopularPosts(
+            @PathVariable String slug,
+            @AuthenticationPrincipal User user
+    ) {
+        MainResponse result = mainService.getPopularPosts(user, slug);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/plink/backend/main/dto/MainResponse.java
+++ b/src/main/java/com/plink/backend/main/dto/MainResponse.java
@@ -1,0 +1,29 @@
+package com.plink.backend.main.dto;
+
+import com.plink.backend.feed.dto.post.PostResponse;
+import com.plink.backend.feed.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+@AllArgsConstructor
+
+public class MainResponse {
+    private PostResponse popularPoll;
+    private List<PostResponse> popularPosts;
+
+    public static MainResponse from(Post popularPoll, List<Post> popularPosts) {
+        return MainResponse.builder()
+                .popularPoll(popularPoll == null ? null : PostResponse.from(popularPoll))
+                .popularPosts(popularPosts == null ? List.of() :
+                        popularPosts.stream()
+                                .map(PostResponse::from)
+                                .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/plink/backend/main/service/MainService.java
+++ b/src/main/java/com/plink/backend/main/service/MainService.java
@@ -2,28 +2,74 @@ package com.plink.backend.main.service;
 
 import com.plink.backend.feed.dto.post.PostResponse;
 import com.plink.backend.feed.entity.Post;
+import com.plink.backend.feed.entity.PostType;
+import com.plink.backend.feed.entity.ReportTargetType;
+import com.plink.backend.feed.repository.HiddenContentRepository;
 import com.plink.backend.feed.repository.PostRepository;
+import com.plink.backend.main.dto.MainResponse;
+import com.plink.backend.user.entity.User;
+import com.plink.backend.user.entity.UserFestival;
+import com.plink.backend.user.repository.UserFestivalRepository;
+import com.plink.backend.user.repository.UserRepository;
+import com.plink.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MainService {
 
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final UserFestivalRepository userFestivalRepository;
+    private final HiddenContentRepository hiddenContentRepository;
 
+    // 인기글 조회하기 (3개)
     @Transactional(readOnly = true)
-    public List<PostResponse> getPopularPosts(String slug) {
-        Pageable top3 = PageRequest.of(0, 3);
-        List<Post> posts = postRepository.findPopularPostsBySlug(slug, top3);
-        return posts.stream()
-                .map(PostResponse::from)
-                .toList();
-    }
+    public MainResponse getPopularPosts(User user, String slug) {
 
+
+        List<Long> hiddenPostIds = List.of(); // 기본값
+
+        // 로그인한 경우만 숨김(신고) 게시글 목록 조회
+
+        if (user != null) {
+            Optional<UserFestival> optionalFestival =
+                    userFestivalRepository.findByUser_UserIdAndFestivalSlug(user.getUserId(), slug);
+
+            if (optionalFestival.isPresent()) {
+                hiddenPostIds = hiddenContentRepository
+                        .findTargetIdsByUserFestivalAndTargetType(optionalFestival.get(), ReportTargetType.POST);
+            }
+        }
+
+        // 인기 POLL 1개 (신고한 게시글 제외)
+        List<Post> popularPolls = postRepository.findPopularPosts(
+                slug, PostType.POLL,
+                hiddenPostIds.isEmpty() ? null : hiddenPostIds,
+                PageRequest.of(0, 1)
+        );
+
+        Post popularPoll = popularPolls.isEmpty() ? null : popularPolls.get(0);
+
+        // 인기 게시글 3개 (POLL 포함 가능하나 위에서 뽑은 앙케이트 제외)
+        List<Long> excludeIds = new ArrayList<>(hiddenPostIds);
+        if (popularPoll != null) excludeIds.add(popularPoll.getId());
+
+        List<Post> popularPosts = postRepository.findPopularPosts(
+                slug, null,
+                excludeIds.isEmpty() ? null : excludeIds,
+                PageRequest.of(0, 3)
+        );
+
+        // DTO 변환 후 응답
+        return MainResponse.from(popularPoll, popularPosts);
+
+    }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,6 +13,9 @@ spring:
       ddl-auto: update
     show-sql: false
     defer-datasource-initialization: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
 
 cloud:
   aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,44 @@
+#application.yml 파일
+
+server:
+  port: 8080
+  servlet:
+    session:
+      timeout: 24h   # 세션 유지 시간
+
 spring:
-  profiles:
-    active: ${SPRING_PROFILES_ACTIVE:local} # 로컬에서 테스트할 때는 local yml 사용
+  datasource:
+    url: jdbc:mysql://localhost:3306/plink
+    username: root
+    password: plink2025
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update     # 운영 단계에서는 validate로 바꾸는 것 추천!
+    show-sql: true         # 콘솔에서 SQL 로그 확인
+    properties:
+      hibernate:
+        format_sql: true   # SQL 로그 포맷팅
+        dialect: org.hibernate.dialect.MySQL8Dialect
+
+  # 세션 관리 (추후 Redis로 확장할 때 대비)
+  session:
+    store-type: none       # 기본값: 서버 메모리(HttpSession)
+    timeout: 24h
+
+
+cloud:
+  aws:
+    s3:
+      bucket: plink-backend-bucket
+      base-url: https://plink-backend-bucket.s3.ap-northeast-2.amazonaws.com/
+    region:
+      static: ap-northeast-2
+
+# CORS 설정
+# Spring Boot 3.x 이상에서는 config 클래스에서 WebMvcConfigurer로 직접 지정해도 OK
+cors:
+  allowed-origins: "http://localhost:5173"   # React dev 서버 주소
+  allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
+  allowed-headers: "*"
+  allow-credentials: true


### PR DESCRIPTION
## 📌 이슈번호 및 PR 유형
<!-- closed #이슈번호 -->
closed #52 
---

## PR 유형 
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [x] Refactor: 리팩토링(동작 변경 없음)
- [ ] Test: 테스트 코드 추가/수정
- [ ] Chore: 빌드/배포/환경설정 등 잡무

---

## 📝 개요
<!-- 이번 PR에서 어떤 작업을 했는지 간단히 설명 -->
- 사용자가 신고한 게시글인 경우 파라미터에 아이디를 넣어도 상세조회가 불가하도록 수정했습니다.
- 그리고 메인에서 인기글을 조회할때도 본인이 신고한 글인 경우 반환되지 않고, 그 다음 순위의 글이 반환되도록 했습니다.
- 추가로 postrepository에서 반복적으로 사용되는 메서드 수정해서 게시글 조회 API에서 검색어와 필터링을 한번에 수행할 수 있도록 했습니다.
---


## Review Notes 
리뷰어에게 공유할 중요 사항이 있다면 알려주세요~!

- 이 다음에는 이미지 관련 로직 수정해야할 것 같습니다.
- 지금 s3관련 파일이 너무 많고 반복되거나 비효율적인 로직도 있는 것 같아서 수정해보겠습니다..
- 게시글 수정에서 이미지를 아예 같이 처리해버리고 싶은데 그게 안됐어서 한번 다시 시도해볼게요

---

## ✅ PR 전 체크리스트
작성하신 코드가 다음의 요구사항을 만족하는지 확인해주세요. 

- [x] 변경 사항에 대한 테스트 여부
- [ ] 불필요한 콘솔 로그 제거
