### PR TITLE
Feat: 프론트용 application-front.yml 분리

### DIFF
--- a/src/main/resources/application-front.yml
+++ b/src/main/resources/application-front.yml
@@ -1,0 +1,20 @@
+# 프론트 테스트용 설정 - H2 설정으로 mysql 없이도 테스트 가능하도록 함
+spring:
+  datasource:
+    url: jdbc:h2:mem:plink;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,44 +1,7 @@
-#application.yml 파일
-
-server:
-  port: 8080
-  servlet:
-    session:
-      timeout: 24h   # 세션 유지 시간
-
 spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/plink
-    username: root
-    password: plink2025
-    driver-class-name: com.mysql.cj.jdbc.Driver
+  profiles:
+    active: local  # 기본은 local (MySQL)
   jpa:
     hibernate:
-      ddl-auto: update     # 운영 단계에서는 validate로 바꾸는 것 추천!
-    show-sql: true         # 콘솔에서 SQL 로그 확인
-    properties:
-      hibernate:
-        format_sql: true   # SQL 로그 포맷팅
-        dialect: org.hibernate.dialect.MySQL8Dialect
-
-  # 세션 관리 (추후 Redis로 확장할 때 대비)
-  session:
-    store-type: none       # 기본값: 서버 메모리(HttpSession)
-    timeout: 24h
-
-
-cloud:
-  aws:
-    s3:
-      bucket: plink-backend-bucket
-      base-url: https://plink-backend-bucket.s3.ap-northeast-2.amazonaws.com/
-    region:
-      static: ap-northeast-2
-
-# CORS 설정
-# Spring Boot 3.x 이상에서는 config 클래스에서 WebMvcConfigurer로 직접 지정해도 OK
-cors:
-  allowed-origins: "http://localhost:5173"   # React dev 서버 주소
-  allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
-  allowed-headers: "*"
-  allow-credentials: true
+      ddl-auto: update
+    show-sql: true


### PR DESCRIPTION
## 📌 이슈번호 및 PR 유형
<!-- closed #이슈번호 -->
closed #57 

---

## PR 유형 
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 리팩토링(동작 변경 없음)
- [ ] Test: 테스트 코드 추가/수정
- [ ] Chore: 빌드/배포/환경설정 등 잡무

---

## 📝 개요
<!-- 이번 PR에서 어떤 작업을 했는지 간단히 설명 -->
프론트분들께서 테스트할 때 MySQL을 로컬에 설치하지 않으셔도 되도록, application.yml을 분기하여 프론트용은 H2 database를 사용하여 임시로 데이터를 자동으로 생성할 수 있도록 했습니다. 

---

## 🔍 변경 사항
<!-- 주요 변경 내용 리스트 -->
<분기된 최종 applciation.yml 구조>
- application.yml
    - 로컬에서는 로컬 변수가 적힌 yml에서 실행되도록 분기하는 역할.
- application-local.yml
    - 로컬에서 실행하기 위한 .env 파일의 기능. 우리 프로젝트의 시크릿 키나 시크릿 변수의 실제 값이 다 들어가 있는 버전.
    - !! 이번 PR에서 application-local.yml 파일 조금 수정되었으니 노션에서 다시 한번 확인 부탁해요!!
- application-prod.yml
    - 배포 환경에서 실행하기 위해 시크릿 변수를 암호화한 버전. 각 변수의 실제 값은 깃허브 세팅에 주입해놓거나, ec2에 터미널로 입력하여 application-prod.yml을 실행시킬 수 있다. 
- application-front.yml
    - 프론트용 테스트 역할. MySQL을 로컬에 설치할 필요 없이, H2만으로 테스트할 수 있도록 함. 
    - 대신 실행 전 터미널에서  `./gradlew bootRun --args='--spring.profiles.active=front'` 라고 환경변수 주입 필수!!! 그래야 application-front.yml로 돌아감!!! 

---

## 📷 스크린샷(선택)
<!-- API 응답 포스트맨 예시 등 -->

---

## Review Notes 
리뷰어에게 공유할 중요 사항이 있다면 알려주세요~!

---

## ✅ PR 전 체크리스트
작성하신 코드가 다음의 요구사항을 만족하는지 확인해주세요. 

- [x] 변경 사항에 대한 테스트 여부
- [ ] 불필요한 콘솔 로그 제거
